### PR TITLE
Added default port in case .env file doesn't exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ commander.option('--port <port>', 'Server Port');
 commander.parse(process.argv);
 const options = commander.opts();
 
-const PORT = options.port || process.env.PORT;
+const PORT = options.port || process.env.PORT || 3000;
 
 http.createServer((req, resp) => {
     const myUrl = url.parse(req.url);


### PR DESCRIPTION
I use and .env file for enviroment vars but gitignore avoid to push it to the remote repo. 
For this case i add other option on index.js to take a default port.
